### PR TITLE
Fixed 'selectItem(index : Int)' not working

### DIFF
--- a/app/src/main/java/com/iammert/readablebottombar/MainActivity.kt
+++ b/app/src/main/java/com/iammert/readablebottombar/MainActivity.kt
@@ -16,7 +16,7 @@ class MainActivity : AppCompatActivity() {
         //bottomBar.setTabItems(R.xml.tabs_disabled)
         var items =  ArrayList<BottomBarItem>()
 
-        items.add(BottomBarItem(0, "Test", 15f,
+        items.add(BottomBarItem(0, 0, "Test", 15f,
                 Color.BLACK, Color.BLACK, getDrawable(R.drawable.ic_home_black_24dp),
                 ReadableBottomBar.ItemType.Icon))
         bottomBar.setTabItems(items)

--- a/app/src/main/java/com/iammert/readablebottombar/MainActivity.kt
+++ b/app/src/main/java/com/iammert/readablebottombar/MainActivity.kt
@@ -1,12 +1,24 @@
 package com.iammert.readablebottombar
 
-import android.support.v7.app.AppCompatActivity
+import android.graphics.Color
 import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import com.iammert.library.readablebottombar.BottomBarItem
+import com.iammert.library.readablebottombar.ReadableBottomBar
 
 class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        val bottomBar : ReadableBottomBar = findViewById<ReadableBottomBar>(R.id.dynamic_bottom_bar)
+        //bottomBar.setTabItems(R.xml.tabs_disabled)
+        var items =  ArrayList<BottomBarItem>()
+
+        items.add(BottomBarItem(0, "Test", 15f,
+                Color.BLACK, Color.BLACK, getDrawable(R.drawable.ic_home_black_24dp),
+                ReadableBottomBar.ItemType.Icon))
+        bottomBar.setTabItems(items)
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -2,28 +2,29 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:context=".MainActivity">
 
     <com.iammert.library.readablebottombar.ReadableBottomBar
         android:layout_width="match_parent"
         android:layout_height="64dp"
         app:rbb_activeItemType="icon"
-        app:rbb_tabs="@xml/tabs"/>
+        app:rbb_tabs="@xml/tabs" />
 
     <com.iammert.library.readablebottombar.ReadableBottomBar
         android:layout_width="match_parent"
         android:layout_height="64dp"
         android:layout_marginTop="64dp"
         app:rbb_activeItemType="text"
-        app:rbb_tabs="@xml/tabs"/>
+        app:rbb_tabs="@xml/tabs" />
 
     <com.iammert.library.readablebottombar.ReadableBottomBar
+        android:id="@+id/dynamic_bottom_bar"
         android:layout_width="match_parent"
         android:layout_height="64dp"
         android:layout_marginTop="64dp"
-        app:rbb_tabs="@xml/tabs"/>
+        app:rbb_tabs="@xml/tabs" />
 
 </LinearLayout>

--- a/app/src/main/res/xml/tabs.xml
+++ b/app/src/main/res/xml/tabs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <tabs>
     <tab
+        id="@+id/home_button"
         drawable="@drawable/ic_home_black_24dp"
         text="@string/home" />
 

--- a/app/src/main/res/xml/tabs_diabled.xml
+++ b/app/src/main/res/xml/tabs_diabled.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tabs>
+    <tab
+        drawable="@drawable/ic_home_black_24dp"
+        text="@string/home" />
+
+    <tab
+        drawable="@drawable/ic_search_black_24dp"
+        text="@string/search" />
+
+</tabs>

--- a/library/src/main/java/com/iammert/library/readablebottombar/BottomBarItem.kt
+++ b/library/src/main/java/com/iammert/library/readablebottombar/BottomBarItem.kt
@@ -5,6 +5,7 @@ import android.support.annotation.ColorInt
 import com.iammert.library.readablebottombar.ReadableBottomBar.ItemType
 
 data class BottomBarItem(
+        val id: Int,
         val index: Int,
         val text: String,
         val textSize: Float,

--- a/library/src/main/java/com/iammert/library/readablebottombar/BottomBarItemConfig.kt
+++ b/library/src/main/java/com/iammert/library/readablebottombar/BottomBarItemConfig.kt
@@ -3,7 +3,8 @@ package com.iammert.library.readablebottombar
 import android.graphics.drawable.Drawable
 
 data class BottomBarItemConfig(
-    val text: String,
-    val drawable: Drawable,
-    val index: Int
+        val id: Int,
+        val text: String,
+        val drawable: Drawable,
+        val index: Int
 )

--- a/library/src/main/java/com/iammert/library/readablebottombar/BottomBarItemView.kt
+++ b/library/src/main/java/com/iammert/library/readablebottombar/BottomBarItemView.kt
@@ -67,11 +67,15 @@ class BottomBarItemView @JvmOverloads constructor(context: Context, attrs: Attri
     }
 
     fun select() {
-        animatedView.startAnimation(translateUpAnimation)
+        translateUpAnimation?.let {
+            animatedView.startAnimation(it)
+        }
     }
 
     fun deselect() {
-        animatedView.startAnimation(translateDownAnimation)
+        translateDownAnimation?.let {
+            animatedView.startAnimation(it)
+        }
     }
 
     private fun initializeAnimations() {

--- a/library/src/main/java/com/iammert/library/readablebottombar/ConfigurationXmlParser.kt
+++ b/library/src/main/java/com/iammert/library/readablebottombar/ConfigurationXmlParser.kt
@@ -32,13 +32,19 @@ class ConfigurationXmlParser(private val context: Context, xmlRes: Int) {
         val attributeCount = parser.attributeCount
         var itemText: String? = null
         var itemDrawable: Drawable? = null
+        var itemId: Int = -1
         for (i in 0 until attributeCount) {
             when (parser.getAttributeName(i)) {
+                KEY_ID -> itemId = parser.getAttributeIntValue(i, -1)
                 KEY_TEXT -> itemText = getText(parser, i)
                 KEY_DRAWABLE -> itemDrawable = getDrawable(parser, i)
             }
         }
-        return BottomBarItemConfig(text = itemText!!, drawable = itemDrawable!!, index = itemConfigList.size)
+        return BottomBarItemConfig(
+                id = itemId,
+                text = itemText!!,
+                drawable = itemDrawable!!,
+                index = itemConfigList.size)
     }
 
     private fun getDrawable(parser: XmlResourceParser, i: Int): Drawable {
@@ -50,6 +56,7 @@ class ConfigurationXmlParser(private val context: Context, xmlRes: Int) {
     }
 
     companion object {
+        const val KEY_ID: String = "id"
         const val KEY_TEXT: String = "text"
         const val KEY_DRAWABLE: String = "drawable"
 

--- a/library/src/main/java/com/iammert/library/readablebottombar/ReadableBottomBar.kt
+++ b/library/src/main/java/com/iammert/library/readablebottombar/ReadableBottomBar.kt
@@ -3,6 +3,7 @@ package com.iammert.library.readablebottombar
 import android.animation.ValueAnimator
 import android.content.Context
 import android.graphics.Color
+import android.support.annotation.XmlRes
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewTreeObserver
@@ -26,12 +27,17 @@ class ReadableBottomBar @JvmOverloads constructor(context: Context, attrs: Attri
         }
     }
 
-    private val bottomBarItemList: List<BottomBarItem>
+    private var bottomBarItemList: List<BottomBarItem>
 
     private var tabInitialSelectedIndex = 0
     private var tabBackgroundColor: Int = Color.WHITE
     private var tabIndicatorColor: Int = Color.BLACK
     private var tabIndicatorHeight: Int = 10
+
+    private var textSize: Float = 15f
+    private var textColor: Int = Color.BLACK
+    private var iconColor: Int = Color.BLACK
+    private var activeItemType: ItemType = ItemType.Icon
 
     private var layoutWidth: Float = 0f
     private var layoutHeight: Float = 0f
@@ -65,10 +71,10 @@ class ReadableBottomBar @JvmOverloads constructor(context: Context, attrs: Attri
         tabIndicatorHeight = typedArray.getDimensionPixelSize(R.styleable.ReadableBottomBar_rbb_indicatorHeight, 10)
         tabInitialSelectedIndex = typedArray.getInt(R.styleable.ReadableBottomBar_rbb_initialIndex, 0)
 
-        val textSize = typedArray.getDimension(R.styleable.ReadableBottomBar_rbb_textSize, 15f)
-        val textColor = typedArray.getColor(R.styleable.ReadableBottomBar_rbb_textColor, Color.BLACK)
-        val iconColor = typedArray.getColor(R.styleable.ReadableBottomBar_rbb_iconColor, Color.BLACK)
-        val activeItemType = ItemType.getType(typedArray.getInt(R.styleable.ReadableBottomBar_rbb_activeItemType, ItemType.Icon.value))
+        textSize = typedArray.getDimension(R.styleable.ReadableBottomBar_rbb_textSize, 15f)
+        textColor = typedArray.getColor(R.styleable.ReadableBottomBar_rbb_textColor, Color.BLACK)
+        iconColor = typedArray.getColor(R.styleable.ReadableBottomBar_rbb_iconColor, Color.BLACK)
+        activeItemType = ItemType.getType(typedArray.getInt(R.styleable.ReadableBottomBar_rbb_activeItemType, ItemType.Icon.value))
 
         val tabXmlResource = typedArray?.getResourceId(R.styleable.ReadableBottomBar_rbb_tabs, 0)
         val bottomBarItemConfigList = ConfigurationXmlParser(context = context, xmlRes = tabXmlResource!!).parse()
@@ -211,6 +217,37 @@ class ReadableBottomBar @JvmOverloads constructor(context: Context, attrs: Attri
         currentSelectedView?.select()
         itemSelectListener?.onItemSelected(index)
     }
+
+
+    public fun setTabItems(items : List<BottomBarItem>) {
+        bottomBarItemList = items
+        post {
+            drawIndicator()
+            drawBottomBarItems()
+        }
+    }
+
+    /*public fun setTabItems(@XmlRes tabResource: Int) {
+        val bottomBarItemConfigList = ConfigurationXmlParser(context = context,
+                xmlRes = tabResource).parse()
+
+        bottomBarItemList = bottomBarItemConfigList.map { config ->
+            BottomBarItem(
+                    config.index,
+                    config.text,
+                    textSize,
+                    textColor,
+                    iconColor,
+                    config.drawable,
+                    activeItemType
+            )
+        }
+        post {
+            drawIndicator()
+            drawBottomBarItems()
+        }
+    }*/
+
 
     companion object {
 

--- a/library/src/main/java/com/iammert/library/readablebottombar/ReadableBottomBar.kt
+++ b/library/src/main/java/com/iammert/library/readablebottombar/ReadableBottomBar.kt
@@ -3,7 +3,6 @@ package com.iammert.library.readablebottombar
 import android.animation.ValueAnimator
 import android.content.Context
 import android.graphics.Color
-import android.support.annotation.XmlRes
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewTreeObserver
@@ -13,7 +12,7 @@ class ReadableBottomBar @JvmOverloads constructor(context: Context, attrs: Attri
     : LinearLayout(context, attrs, defStyleAttr) {
 
     interface ItemSelectListener {
-        fun onItemSelected(index: Int)
+        fun onItemSelected(index: Int, id: Int)
     }
 
     enum class ItemType(val value: Int) {
@@ -84,6 +83,7 @@ class ReadableBottomBar @JvmOverloads constructor(context: Context, attrs: Attri
 
         bottomBarItemList = bottomBarItemConfigList.map { config ->
             BottomBarItem(
+                    config.id,
                     config.index,
                     config.text,
                     textSize,
@@ -126,7 +126,7 @@ class ReadableBottomBar @JvmOverloads constructor(context: Context, attrs: Attri
                 if (TAG_CONTAINER == getChildAt(i).tag) {
                     val selectedItemView = ((getChildAt(i) as LinearLayout).getChildAt(index) as BottomBarItemView)
                     if (selectedItemView != currentSelectedView) {
-                        onSelected(item.index, selectedItemView)
+                        onSelected(item.id, item.index, selectedItemView)
                     }
                 }
             }
@@ -161,7 +161,7 @@ class ReadableBottomBar @JvmOverloads constructor(context: Context, attrs: Attri
                         return@setOnClickListener
                     }
 
-                    onSelected(item.index, this)
+                    onSelected(item.id, item.index, this)
                 }
             }
 
@@ -209,44 +209,23 @@ class ReadableBottomBar @JvmOverloads constructor(context: Context, attrs: Attri
         indicatorAnimator?.start()
     }
 
-    private fun onSelected(index: Int, bottomBarItemView: BottomBarItemView) {
+    private fun onSelected(id: Int, index: Int, bottomBarItemView: BottomBarItemView) {
         animateIndicator(index)
 
         currentSelectedView?.deselect()
         currentSelectedView = bottomBarItemView
         currentSelectedView?.select()
-        itemSelectListener?.onItemSelected(index)
+        itemSelectListener?.onItemSelected(index, id)
     }
 
 
-    public fun setTabItems(items : List<BottomBarItem>) {
+    public fun setTabItems(items: List<BottomBarItem>) {
         bottomBarItemList = items
         post {
             drawIndicator()
             drawBottomBarItems()
         }
     }
-
-    /*public fun setTabItems(@XmlRes tabResource: Int) {
-        val bottomBarItemConfigList = ConfigurationXmlParser(context = context,
-                xmlRes = tabResource).parse()
-
-        bottomBarItemList = bottomBarItemConfigList.map { config ->
-            BottomBarItem(
-                    config.index,
-                    config.text,
-                    textSize,
-                    textColor,
-                    iconColor,
-                    config.drawable,
-                    activeItemType
-            )
-        }
-        post {
-            drawIndicator()
-            drawBottomBarItems()
-        }
-    }*/
 
 
     companion object {


### PR DESCRIPTION
Fixed `selectItem(index : Int)` not working when called from `onCreate` in an activity. It happens because none of the `BottomBarItemView` items have been layed out yet so `childCount` is `0` which is used by `ReadableBottomBar` to enumerate child views during selection.